### PR TITLE
Fixed changed_lines calculation

### DIFF
--- a/locust/parse.py
+++ b/locust/parse.py
@@ -189,7 +189,7 @@ class LocustVisitor(ast.NodeVisitor):
                         ):
                             end_line = definition.end_line
 
-                        changed_lines += end_line - start + 1
+                        changed_lines += end_line - max(start, definition.line) + 1
 
                 locust_changes.append(
                     LocustChange(


### PR DESCRIPTION
Fixes https://github.com/simiotics/locust/issues/2

The issue was that we were going all the way back to the beginning of
the relevant hunk boundary when we should have been going back to the
max of the hunk start and the definition start.

One line change.