### PR TITLE
Fixed small issue in deeply nested HTML summaries

### DIFF
--- a/locust/render.py
+++ b/locust/render.py
@@ -174,9 +174,11 @@ def render_change_as_html(
         change_elements.extend([E.BR(), E.B("Changes:")])
     child_elements = []
     for child in change["children"]:
-        child_elements.append(
-            render_change_as_html(child, filepath, current_depth + 1, max_depth)
+        child_element = render_change_as_html(
+            child, filepath, current_depth + 1, max_depth
         )
+        if child_element is not None:
+            child_elements.append(child_element)
     change_elements.append(E.UL(*child_elements))
 
     return E.LI(*change_elements)

--- a/locust/version.py
+++ b/locust/version.py
@@ -1,4 +1,4 @@
-LOCUST_VERSION = "0.1.0"
+LOCUST_VERSION = "0.1.1"
 
 if __name__ == "__main__":
     print(LOCUST_VERSION)


### PR DESCRIPTION
The core HTML render wasn't correctly handling None responses at
max_depth cutoff.

mypy: passed
black: passed