### PR TITLE
Using pull_request_target event for locust action

### DIFF
--- a/.github/workflows/locust.yaml
+++ b/.github/workflows/locust.yaml
@@ -1,6 +1,6 @@
 name: Locust summary
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   build:


### PR DESCRIPTION
This fixes an issue where PRs from forked repos do not have permissions
to post comments on the base repo.

See GitHub release of `pull_request_target` for more details:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

mypy: passed
black: passed