### PR TITLE
locust action now uses pull_request_target event

### DIFF
--- a/.github/workflows/locust.yaml
+++ b/.github/workflows/locust.yaml
@@ -1,14 +1,21 @@
 name: Locust summary
 
-on: [pull_request]
+on: [ pull_request_target ]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+      - name: PR head repo
+        id: head_repo_name
+        run: |
+          HEAD_REPO_NAME=$(jq -r '.pull_request.head.repo.full_name' "$GITHUB_EVENT_PATH")
+          echo "PR head repo: $HEAD_REPO_NAME"
+          echo "::set-output name=repo::$HEAD_REPO_NAME"
       - name: Checkout git repo
         uses: actions/checkout@v2
         with:
+          repository: ${{ steps.head_repo_name.outputs.repo }}
           fetch-depth: 0
       - name: Generate Locust summary
         uses: simiotics/locust-action@main


### PR DESCRIPTION
This fixes an issue with GitHub Actions whereby pull_request action
environments have read-only access to their base repos.

See GitHub's announcement of `pull_request_target` for more details:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

mypy: passed
black: passed